### PR TITLE
Add KBHit POSIX-compatible script, and replace msvcrt in Brainkit.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
 # brainkit
 An open-source, Arduino based platform for tDCS, tACS, and analysis of neurophysiological data
 We'll eventuall have a good manual in this README file, but for now http://quicktotheratcave.tumblr.com/post/124541990103/brainkit-1-0-released has a good rundown on how to set up and use BrainKit.
+
+**Note**: Requires EasyGui 9.8.0 to be compatible with Python 2.7.9.

--- a/brainkit.py
+++ b/brainkit.py
@@ -4,7 +4,8 @@ import headset
 import time
 import urllib2
 import numpy as np
-import msvcrt
+import kbhit
+
 imprintSham=False
 current_milli_time = lambda: int(round(time.time() * 1000))
 stimModes={"F4":0,"C4":1,"O2":2,"C3":3,"F3":4,"O1":5,"Reference electrode":6}
@@ -76,12 +77,12 @@ def recordData(filename):
     headset.flushData()
     print("Data aquistion is running, press space to stop.")
     samples=0
-    while msvcrt.kbhit():
-        msvcrt.getch()
+    while kbhit.kbhit():
+        kbhit.getch()
     while keepRunning:
         samples=samples+1
-        if msvcrt.kbhit():
-            theKey=msvcrt.getch()
+        if kbhit.kbhit():
+            theKey=kbhit.getch()
             if " " in theKey:
                 keepRunning=False
                 print("Interrupt")
@@ -761,8 +762,8 @@ while True:
                     keepRunning=True
                     displayCurrent=False
                     while keepRunning:
-                        if msvcrt.kbhit():
-                            thechar=msvcrt.getch()
+                        if kbhit.kbhit():
+                            thechar=kbhit.getch()
                             if " " in thechar:
                                 keepRunning=False
                             if "c" in thechar:

--- a/brainkit.py
+++ b/brainkit.py
@@ -54,11 +54,16 @@ def connectStim():
             portSelect="Cancel"
         else:
             print(str(thePorts))
-            portSelect=eg.buttonbox(title="Stimulator port", msg="Select the port to which the stimulator is connected. If you do not know the port, connected or unplug the stimultor and click refresh", choices=[thePorts, "Refresh"])
-        if portSelect and "Refresh" not in portSelect:
+            print([port.__str__() for port in thePorts])
+            portSelect=eg.buttonbox(title="Stimulator port", msg="Select the port to which the stimulator is connected. If you do not know the port, connected or unplug the stimultor and click refresh", choices=[port.__str__() for port in thePorts]+["Refresh"])
+            
+        if portSelect and "Refresh" not in portSelect:            
             accepted=True
-            choice=portSelect
-    if "Cancel" not in portSelect:
+            #choice=portSelect
+            # parse the device selection
+            choice=[port for port in thePorts if port.device == portSelect.split()[0]]
+            
+        if "Cancel" not in portSelect:
             try:
                 print(str(choice))
                 print("Attempting to connect to stimulator...")
@@ -860,10 +865,13 @@ while True:
                 portSelect="Cancel"
             else:
                 print(str(thePorts))
-                portSelect=eg.buttonbox(title="Stimulator port", msg="Select the port to which the stimulator is connected. If you do not know the port, connected or unplug the stimultor and click refresh", choices=[thePorts, "Refresh"])
-            if portSelect and "Refresh" not in portSelect:
-                accepted=True
-                choice=portSelect
+                portSelect=eg.buttonbox(title="Stimulator port", msg="Select the port to which the stimulator is connected. If you do not know the port, connected or unplug the stimultor and click refresh", choices=[port.__str__() for port in thePorts]+["Refresh"])
+        if portSelect and "Refresh" not in portSelect:            
+            accepted=True
+            #choice=portSelect
+            # parse the device selection
+            choice=[port for port in thePorts if port.device == portSelect.split()[0]]
+
         if "Cancel" not in portSelect:
                 try:
                     print(str(choice))

--- a/brainkit.py
+++ b/brainkit.py
@@ -866,12 +866,9 @@ while True:
             else:
                 print(str(thePorts))
                 portSelect=eg.buttonbox(title="Stimulator port", msg="Select the port to which the stimulator is connected. If you do not know the port, connected or unplug the stimultor and click refresh", choices=[port.__str__() for port in thePorts]+["Refresh"])
-        if portSelect and "Refresh" not in portSelect:            
-            accepted=True
-            #choice=portSelect
-            # parse the device selection
-            choice=[port for port in thePorts if port.device == portSelect.split()[0]]
-
+            if portSelect and "Refresh" not in portSelect:
+                accepted=True
+                choice=[ port for port in thePorts if port.device == portSelect.split()[0] ]
         if "Cancel" not in portSelect:
                 try:
                     print(str(choice))

--- a/headset.py
+++ b/headset.py
@@ -30,9 +30,10 @@ def startStim(mode):
     
 def flushData():
     ser.flushInput()
-def getPorts():
     
+def getPorts():    
     return (list(serial.tools.list_ports.comports()))
+
 def getData():
         theData=ser.readline()
         if not stimulator:

--- a/kbhit.py
+++ b/kbhit.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python
+''' From http://home.wlu.edu/~levys/software/kbhit.py '''
+'''
+A Python class implementing KBHIT, the standard keyboard-interrupt poller.
+Works transparently on Windows and Posix (Linux, Mac OS X).  Doesn't work
+with IDLE.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as 
+published by the Free Software Foundation, either version 3 of the 
+License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+'''
+
+import os
+
+# Windows
+if os.name == 'nt':
+    import msvcrt
+
+# Posix (Linux, OS X)
+else:
+    import sys
+    import termios
+    import atexit
+    from select import select
+
+
+class KBHit:
+    
+    def __init__(self):
+        '''Creates a KBHit object that you can call to do various keyboard things.
+        '''
+
+        if os.name == 'nt':
+            pass
+        
+        else:
+    
+            # Save the terminal settings
+            self.fd = sys.stdin.fileno()
+            self.new_term = termios.tcgetattr(self.fd)
+            self.old_term = termios.tcgetattr(self.fd)
+    
+            # New terminal setting unbuffered
+            self.new_term[3] = (self.new_term[3] & ~termios.ICANON & ~termios.ECHO)
+            termios.tcsetattr(self.fd, termios.TCSAFLUSH, self.new_term)
+    
+            # Support normal-terminal reset at exit
+            atexit.register(self.set_normal_term)
+    
+    
+    def set_normal_term(self):
+        ''' Resets to normal terminal.  On Windows this is a no-op.
+        '''
+        
+        if os.name == 'nt':
+            pass
+        
+        else:
+            termios.tcsetattr(self.fd, termios.TCSAFLUSH, self.old_term)
+
+
+    def getch(self):
+        ''' Returns a keyboard character after kbhit() has been called.
+            Should not be called in the same program as getarrow().
+        '''
+        
+        s = ''
+        
+        if os.name == 'nt':
+            return msvcrt.getch().decode('utf-8')
+        
+        else:
+            return sys.stdin.read(1)
+                        
+
+    def getarrow(self):
+        ''' Returns an arrow-key code after kbhit() has been called. Codes are
+        0 : up
+        1 : right
+        2 : down
+        3 : left
+        Should not be called in the same program as getch().
+        '''
+        
+        if os.name == 'nt':
+            msvcrt.getch() # skip 0xE0
+            c = msvcrt.getch()
+            vals = [72, 77, 80, 75]
+            
+        else:
+            c = sys.stdin.read(3)[2]
+            vals = [65, 67, 66, 68]
+        
+        return vals.index(ord(c.decode('utf-8')))
+        
+
+    def kbhit(self):
+        ''' Returns True if keyboard character was hit, False otherwise.
+        '''
+        if os.name == 'nt':
+            return msvcrt.kbhit()
+        
+        else:
+            dr,dw,de = select([sys.stdin], [], [], 0)
+            return dr != []
+    
+    
+# Test    
+if __name__ == "__main__":
+    
+    kb = KBHit()
+
+    print('Hit any key, or ESC to exit')
+
+    while True:
+
+        if kb.kbhit():
+            c = kb.getch()
+            if ord(c) == 27: # ESC
+                break
+            print(c)
+             
+    kb.set_normal_term()
+        


### PR DESCRIPTION
The source of the Windows-only compatibility seemed to come from the fact you were using msvcrt. I found a script that implements the kbhit behaviour in both Windows and Linux/OS X polymorphically, and used it as a substitute for msvcrt instead. It should work directly.
